### PR TITLE
feat: add health endpoint and improve nano-remove

### DIFF
--- a/staryo-site-new/netlify.toml
+++ b/staryo-site-new/netlify.toml
@@ -1,5 +1,15 @@
+[build]
+  functions = "netlify/functions"
+  node_bundler = "esbuild"
+
 [functions]
-  directory = "netlify/functions"
+  node_bundler = "esbuild"
+  external_node_modules = ["node-fetch"]
+
+[[headers]]
+  for = "/.netlify/functions/*"
+  [headers.values]
+    Access-Control-Allow-Origin = "*"
 
 [[redirects]]
   # Proxy for nano remove

--- a/staryo-site-new/netlify/functions/health.js
+++ b/staryo-site-new/netlify/functions/health.js
@@ -1,0 +1,16 @@
+exports.handler = async function() {
+  return {
+    statusCode: 200,
+    headers: {
+      'Content-Type': 'application/json',
+      'Cache-Control': 'no-store',
+      'Access-Control-Allow-Origin': '*',
+    },
+    body: JSON.stringify({
+      ok: true,
+      ts: Date.now(),
+      env: process.env.CONTEXT || 'prod',
+      version: process.env.APP_VERSION || '0.1.0'
+    })
+  };
+};


### PR DESCRIPTION
## Summary
- add `health` function returning uptime info
- overhaul `nano-remove` to validate input, call upstream API, and log errors
- configure Netlify build with esbuild and default CORS headers

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68c00b6bdd0883339bcd1bede2bf8d92